### PR TITLE
BlinkStick.device → BlinkStick.Device (i.e. export it)

### DIFF
--- a/blinkstick.go
+++ b/blinkstick.go
@@ -49,7 +49,7 @@ func FindAll() ([]BlinkStick, error) {
 			fmt.Fprintln(os.Stderr, "Could not grab Serial for BlinkStick device", err)
 		}
 		blinksticks = append(blinksticks, BlinkStick{
-			device: device,
+			Device: device,
 			Inverse: false, // TODO: The device knows this, right? We should query for it.
 			Serial: serial,
 		})
@@ -59,7 +59,7 @@ func FindAll() ([]BlinkStick, error) {
 
 // The BlinkStick struct represents an individual BlinkStick device.
 type BlinkStick struct {
-	device   *gousb.Device
+	Device   *gousb.Device
 	Serial   string
 	Inverse  bool
 	RGB      bool // Currently unimplemented, will be true if the strip uses RGB format instead of the default GRB.
@@ -71,7 +71,7 @@ func (stk *BlinkStick) GetLEDCount() int {
 	if stk.ledCount == 0 {
 		buffer := make([]byte, 2)
 
-		responseLen, err := stk.device.Control(0x80|0x20, 0x01, 0x81, 0x00, buffer)
+		responseLen, err := stk.Device.Control(0x80|0x20, 0x01, 0x81, 0x00, buffer)
 		if err != nil || responseLen < 2 {
 			return -1
 		}
@@ -179,7 +179,7 @@ func (stk *BlinkStick) SetLEDData(channel byte, data []byte) error {
 
 // A razor thin wrapper around gousb.Device.Control().
 func (stk *BlinkStick) control(requestType, request uint8, val, idx uint16, data []byte) error {
-	_, err := stk.device.Control(requestType, request, val, idx, data)
+	_, err := stk.Device.Control(requestType, request, val, idx, data)
 	return err
 }
 


### PR DESCRIPTION
Nice library! I plan to add a couple more features.

This pull requests exports gousb's [Device](https://godoc.org/github.com/google/gousb#Device) by letting the struct field's name start with a capital letter.
It just makes "quick hacks" on the user side much easier. For example to access the [DeviceDesc struct](https://godoc.org/github.com/google/gousb#DeviceDesc):

```go
fmt.Printf("Bus: %d\n", stick.Device.Desc.Bus)
fmt.Printf("Address: %d\n", stick.Device.Desc.Address)
fmt.Printf("Speed: %s\n", stick.Device.Desc.Speed)
fmt.Printf("Port: %d\n", stick.Device.Desc.Port)
fmt.Printf("Spec: %s\n", stick.Device.Desc.Spec)
fmt.Printf("Device: %s\n", stick.Device.Desc.Device)
fmt.Printf("Vendor: 0x%s\n", stick.Device.Desc.Vendor)
fmt.Printf("Product: 0x%s\n", stick.Device.Desc.Product)
fmt.Printf("Class: %s\n", stick.Device.Desc.Class)
fmt.Printf("SubClass: %s\n", stick.Device.Desc.SubClass)
fmt.Printf("Protocol: %s\n", stick.Device.Desc.Protocol)
fmt.Printf("MaxControlPacketSize: %d\n", stick.Device.Desc.MaxControlPacketSize)
fmt.Printf("# of Configs: %d\n", len(stick.Device.Desc.Configs))
```