### PR TITLE
[new]: GetMode() and SetMode()

### DIFF
--- a/blinkstick.go
+++ b/blinkstick.go
@@ -152,6 +152,22 @@ func (stk *BlinkStick) SetAllRGB(channel, r, g, b byte) error {
 	return stk.SetLEDData(channel, data)
 }
 
+// SetMode sets the BlinkStick to a specific mode.
+//
+// The possible modes are:  0 = analog RGB, 1 = inverse,
+// 2 = addressable multi LED, 3 = addressable mirrored multi LED.
+// After changing the mode, wait for ~10 ms with further queries.
+func (stk *BlinkStick) SetMode(mode byte) error {
+	return stk.control(0x20, 0x9, 0x4, 0, []byte{4, mode})
+}
+
+// GetMode fetches the mode of the BlinkStick.
+func (stk *BlinkStick) GetMode() (byte, error) {
+	buffer := make([]byte, 2)
+	err := stk.control(0x80|0x20, 0x1, 0x4, 0, buffer)
+	return buffer[1], err
+}
+
 // GetLEDData retrieves the LED data from the device.
 func (stk *BlinkStick) GetLEDData(count int) ([]byte, error) {
 	reportID, maxLEDs := stk.getReportID(count*3)


### PR DESCRIPTION
The modes are partly documented here:
https://www.blinkstick.com/help/tutorials/blinkstick-pro-modes

Mode 3 is hardly documented but mentioned at some places like

* https://forums.blinkstick.com/t/led-count-detection/145/2,
* https://forums.blinkstick.com/t/blinkstick-client-2-0-rc-release/342/7, and
* [BlinkStickClient/Forms/ConfigureBlinkStickDialog.cs#L179](https://github.com/arvydas/blinkstick-client/blob/a4d651457cde66f66a642bf5a3967e0e2bc66fee/BlinkStickClient/Forms/ConfigureBlinkStickDialog.cs#L179)